### PR TITLE
make rabbitMQ input binding could configure the Qos of Consumer. (#457)

### DIFF
--- a/bindings/rabbitmq/rabbitmq_test.go
+++ b/bindings/rabbitmq/rabbitmq_test.go
@@ -25,31 +25,39 @@ func TestParseMetadata(t *testing.T) {
 		expectedDeleteWhenUnused bool
 		expectedDurable          bool
 		expectedTTL              *time.Duration
+		expectedPrefetchCount    int
 	}{
 		{
 			name:                     "Delete / Durable",
-			properties:               map[string]string{"QueueName": queueName, "Host": host, "DeleteWhenUnused": "true", "Durable": "true"},
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "true", "durable": "true"},
 			expectedDeleteWhenUnused: true,
 			expectedDurable:          true,
 		},
 		{
-			name:                     "Not Delete / Not Durable",
-			properties:               map[string]string{"QueueName": queueName, "Host": host, "DeleteWhenUnused": "false", "Durable": "false"},
+			name:                     "Not Delete / Not durable",
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "false", "durable": "false"},
 			expectedDeleteWhenUnused: false,
 			expectedDurable:          false,
 		},
 		{
 			name:                     "With one second TTL",
-			properties:               map[string]string{"QueueName": queueName, "Host": host, "DeleteWhenUnused": "false", "Durable": "false", bindings.TTLMetadataKey: "1"},
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "false", "durable": "false", bindings.TTLMetadataKey: "1"},
 			expectedDeleteWhenUnused: false,
 			expectedDurable:          false,
 			expectedTTL:              &oneSecondTTL,
 		},
 		{
 			name:                     "Empty TTL",
-			properties:               map[string]string{"QueueName": queueName, "Host": host, "DeleteWhenUnused": "false", "Durable": "false", bindings.TTLMetadataKey: ""},
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "false", "durable": "false", bindings.TTLMetadataKey: ""},
 			expectedDeleteWhenUnused: false,
 			expectedDurable:          false,
+		},
+		{
+			name:                     "With one prefetchCount",
+			properties:               map[string]string{"queueName": queueName, "host": host, "deleteWhenUnused": "false", "durable": "false", "prefetchCount": "1"},
+			expectedDeleteWhenUnused: false,
+			expectedDurable:          false,
+			expectedPrefetchCount:    1,
 		},
 	}
 
@@ -65,6 +73,7 @@ func TestParseMetadata(t *testing.T) {
 			assert.Equal(t, tt.expectedDeleteWhenUnused, r.metadata.DeleteWhenUnused)
 			assert.Equal(t, tt.expectedDurable, r.metadata.Durable)
 			assert.Equal(t, tt.expectedTTL, r.metadata.defaultQueueTTL)
+			assert.Equal(t, tt.expectedPrefetchCount, r.metadata.PrefetchCount)
 		})
 	}
 }
@@ -79,15 +88,15 @@ func TestParseMetadataWithInvalidTTL(t *testing.T) {
 	}{
 		{
 			name:       "Whitespaces TTL",
-			properties: map[string]string{"QueueName": queueName, "Host": host, bindings.TTLMetadataKey: "  "},
+			properties: map[string]string{"queueName": queueName, "host": host, bindings.TTLMetadataKey: "  "},
 		},
 		{
 			name:       "Negative ttl",
-			properties: map[string]string{"QueueName": queueName, "Host": host, bindings.TTLMetadataKey: "-1"},
+			properties: map[string]string{"queueName": queueName, "host": host, bindings.TTLMetadataKey: "-1"},
 		},
 		{
 			name:       "Non-numeric ttl",
-			properties: map[string]string{"QueueName": queueName, "Host": host, bindings.TTLMetadataKey: "abc"},
+			properties: map[string]string{"queueName": queueName, "host": host, bindings.TTLMetadataKey: "abc"},
 		},
 	}
 


### PR DESCRIPTION
* update logger form nats-io's to dapr's

* run go mod tidy and go mod delete the nats-io gnatsd

* update rabbitmq prefetch feature because want to set each instance the number of messages could  hold in once until ack.

* update for parse int

* update parseMetadata of rabbitMQ to read prefetchCount by string.

* [update rabbitMQ binding parseMetadata] Make error clear

* [in rabbitMQ metadata parse] fix the bug of golint

* update rabbitMQ with a new parseMetadata way.

Co-authored-by: Yaron Schneider <yaronsc@microsoft.com>

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation / Created issue in the https://github.com/dapr/docs/ repo: dapr/docs#_[issue number]_
